### PR TITLE
Remove call to alt.renderers

### DIFF
--- a/Pipfile
+++ b/Pipfile
@@ -1,0 +1,17 @@
+[[source]]
+name = "pypi"
+url = "https://pypi.org/simple"
+verify_ssl = true
+
+[dev-packages]
+pytest = "*"
+
+[packages]
+jupyter = "*"
+pandas = "*"
+numpy = "*"
+altair = "*"
+vega = "*"
+
+[requires]
+python_version = "3.7"

--- a/altair/Carbon Emissions.ipynb
+++ b/altair/Carbon Emissions.ipynb
@@ -42,9 +42,7 @@
     "     \n",
     "import pandas as pd\n",
     "import numpy as np\n",
-    "import altair as alt\n",
-    "\n",
-    "alt.renderers.enable('notebook')"
+    "import altair as alt\n"
    ]
   },
   {


### PR DESCRIPTION
Altair 4.0 (latest release) does not require a special rendered for Jupyter. This line of code (alt.renderers.enable('notebook')) was causing errors.
See comments here: https://github.com/altair-viz/altair/issues/1114